### PR TITLE
Fix get P2PNVlinkType error

### DIFF
--- a/internal/links/device.go
+++ b/internal/links/device.go
@@ -97,7 +97,7 @@ func GetNVLink(dev1 device.Device, dev2 device.Device) (P2PLinkType, error) {
 
 	nvlink := P2PLinkUnknown
 	for _, pciInfo := range pciInfos {
-		if pciInfo.BusID() == dev2BusID {
+		if pciInfo.BusID() != dev2BusID {
 			continue
 		}
 		switch nvlink {


### PR DESCRIPTION
Please correct me if not right. 

Since we want to get the nvlink account in-between two devices, then we should skip if the busID not match.