### PR TITLE
Ensure Max Left Score

### DIFF
--- a/gpuallocator/besteffort_test.go
+++ b/gpuallocator/besteffort_test.go
@@ -118,6 +118,14 @@ func TestBestEffortAllocate(t *testing.T) {
 			1,
 			[]int{},
 		},
+		{
+			"Left Score Must Max",
+			New8xA10Node().Devices(),
+			[]int{0, 1, 2, 3, 4, 5},
+			[]int{},
+			2,
+			[]int{4, 5},
+		},
 	}
 
 	RunPolicyAllocTests(t, policy, tests)

--- a/gpuallocator/common_test.go
+++ b/gpuallocator/common_test.go
@@ -407,6 +407,54 @@ func NewDGX1VoltaNode() TestNode {
 	return node
 }
 
+func New8xA10Node() TestNode {
+	node := TestNode{
+		NewTestGPU(0),
+		NewTestGPU(1),
+		NewTestGPU(2),
+		NewTestGPU(3),
+		NewTestGPU(4),
+		NewTestGPU(5),
+		NewTestGPU(6),
+		NewTestGPU(7),
+	}
+
+	// NVLinks
+	node.AddLink(0, 1, nvml.SingleNVLINKLink)
+	node.AddLink(0, 2, nvml.SingleNVLINKLink)
+	node.AddLink(0, 3, nvml.SingleNVLINKLink)
+
+	node.AddLink(1, 0, nvml.SingleNVLINKLink)
+	node.AddLink(1, 2, nvml.SingleNVLINKLink)
+	node.AddLink(1, 3, nvml.SingleNVLINKLink)
+
+	node.AddLink(2, 0, nvml.SingleNVLINKLink)
+	node.AddLink(2, 1, nvml.SingleNVLINKLink)
+	node.AddLink(2, 3, nvml.SingleNVLINKLink)
+
+	node.AddLink(3, 0, nvml.SingleNVLINKLink)
+	node.AddLink(3, 1, nvml.SingleNVLINKLink)
+	node.AddLink(3, 2, nvml.SingleNVLINKLink)
+
+	node.AddLink(4, 5, nvml.SingleNVLINKLink)
+	node.AddLink(4, 6, nvml.SingleNVLINKLink)
+	node.AddLink(4, 7, nvml.SingleNVLINKLink)
+
+	node.AddLink(5, 4, nvml.SingleNVLINKLink)
+	node.AddLink(5, 6, nvml.SingleNVLINKLink)
+	node.AddLink(5, 7, nvml.SingleNVLINKLink)
+
+	node.AddLink(6, 4, nvml.SingleNVLINKLink)
+	node.AddLink(6, 5, nvml.SingleNVLINKLink)
+	node.AddLink(6, 7, nvml.SingleNVLINKLink)
+
+	node.AddLink(7, 4, nvml.SingleNVLINKLink)
+	node.AddLink(7, 5, nvml.SingleNVLINKLink)
+	node.AddLink(7, 6, nvml.SingleNVLINKLink)
+
+	return node
+}
+
 func NewDGX2VoltaNode() TestNode {
 	return nil
 }


### PR DESCRIPTION
What I mainly do in the PR:

In the card selection policy, on the premise of ensuring that the selected card group has the highest score, try to make the remaining cards have higher scores.

for example In the following topology, if cards 0-5 are within the candidate range and two cards are selected at this time, card 4-5 should be selected instead of 0-1 or 2-3, because this can ensure the remaining 0-3 The mutual communication between cards is optimal and is conducive to the subsequent allocation of 4-card services.

![image](https://github.com/NVIDIA/go-gpuallocator/assets/15684846/e9e50b80-9bf5-4dd4-8934-0a1e263efbbb)

This PR does not introduce additional complexity. It further calculates the scores of the remaining cards based on the original scoring logic to assist in decision-making.
