### PR TITLE
[go.mod] remove extraneous replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,27 +14,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace (
-	k8s.io/api => k8s.io/api v0.18.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.18.2
-	k8s.io/apiserver => k8s.io/apiserver v0.18.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.2
-	k8s.io/client-go => k8s.io/client-go v0.18.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.2
-	k8s.io/code-generator => k8s.io/code-generator v0.18.2
-	k8s.io/component-base => k8s.io/component-base v0.18.2
-	k8s.io/cri-api => k8s.io/cri-api v0.18.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
-	k8s.io/kubectl => k8s.io/kubectl v0.18.2
-	k8s.io/kubelet => k8s.io/kubelet v0.18.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2
-	k8s.io/metrics => k8s.io/metrics v0.18.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.2
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,24 +22,3 @@ github.com/stretchr/testify/require
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# k8s.io/api => k8s.io/api v0.18.2
-# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.2
-# k8s.io/apimachinery => k8s.io/apimachinery v0.18.2
-# k8s.io/apiserver => k8s.io/apiserver v0.18.2
-# k8s.io/cli-runtime => k8s.io/cli-runtime v0.18.2
-# k8s.io/client-go => k8s.io/client-go v0.18.2
-# k8s.io/cloud-provider => k8s.io/cloud-provider v0.18.2
-# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.18.2
-# k8s.io/code-generator => k8s.io/code-generator v0.18.2
-# k8s.io/component-base => k8s.io/component-base v0.18.2
-# k8s.io/cri-api => k8s.io/cri-api v0.18.2
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.18.2
-# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.2
-# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.18.2
-# k8s.io/kube-proxy => k8s.io/kube-proxy v0.18.2
-# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.18.2
-# k8s.io/kubectl => k8s.io/kubectl v0.18.2
-# k8s.io/kubelet => k8s.io/kubelet v0.18.2
-# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.18.2
-# k8s.io/metrics => k8s.io/metrics v0.18.2
-# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.18.2


### PR DESCRIPTION
We don't use the k8s.io dependencies directly in the repo, so there is no point in adding replace directives here.