### PR TITLE
skip lint check

### DIFF
--- a/internal/links/pciinfo.go
+++ b/internal/links/pciinfo.go
@@ -32,15 +32,16 @@ type PciInfo nvml.PciInfo
 // BusID provides a utility function that returns the string representation of the bus ID.
 // Note that the []int8 slice member is named BusId.
 func (p PciInfo) BusID() string {
-	var bytes []byte
+	var pbytes []byte
 	for _, b := range p.BusId {
-		if b >= 0 && byte(b) == '\x00' {
+		// #nosec G115
+		if byte(b) == '\x00' {
 			break
 		}
 		// #nosec G115
-		bytes = append(bytes, byte(b))
+		pbytes = append(pbytes, byte(b))
 	}
-	id := strings.ToLower(string(bytes))
+	id := strings.ToLower(string(pbytes))
 
 	if id != "0000" {
 		id = strings.TrimPrefix(id, "0000")


### PR DESCRIPTION
skip lint check, rename bytes variable as it overwrites bytes package
without the # nosec: G115 marker, the linter gives this output:
```
golangci-lint run ./...
internal/links/pciinfo.go:37:10: G115: integer overflow conversion int8 -> byte (gosec)
		if byte(b) == '\x00' {
		       ^
internal/links/pciinfo.go:40:31: G115: integer overflow conversion int8 -> byte (gosec)
		pbytes = append(pbytes, byte(b))
		                            ^
2 issues:
* gosec: 2
make: *** [Makefile:55: golangci-lint] Error 1
```
Local run passes with the flags.