### PR TITLE
fix: exclude padded sets from best-effort allocation

### DIFF
--- a/gpuallocator/besteffort_policy.go
+++ b/gpuallocator/besteffort_policy.go
@@ -67,10 +67,11 @@ func (p *bestEffortPolicy) Allocate(available []*Device, required []*Device, siz
 	})
 
 	// Filter the 'bestPartition' to only include sets containing all of the
-	// 'required' devices (which may be nil so all sets will be valid).
+	// 'required' devices and no padding. A padded set does not satisfy the
+	// requested allocation size, even if it has the highest score.
 	filteredBestPartition := [][]*Device{}
 	for _, set := range bestPartition {
-		if gpuSetContainsAll(set, required) {
+		if gpuSetContainsAll(set, required) && gpuSetCountPadding(set) == 0 {
 			filteredBestPartition = append(filteredBestPartition, set)
 		}
 	}

--- a/gpuallocator/besteffort_test.go
+++ b/gpuallocator/besteffort_test.go
@@ -5,6 +5,10 @@ package gpuallocator
 import (
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/go-gpuallocator/internal/links"
 )
 
 func sortGPUSetOfSets(sos [][]*Device) {
@@ -509,4 +513,45 @@ func TestBestEffortDGX1VoltaGPUAllocEight(t *testing.T) {
 	}
 
 	RunAllocTests(t, allocator, tests)
+}
+
+func TestBestEffortAllocateExcludesPadding(t *testing.T) {
+	node := TestNode{NewTestGPU(0), NewTestGPU(1), NewTestGPU(2), NewTestGPU(3), NewTestGPU(4)}
+	// The NVLink pair scores higher than the PCIe-connected triple. Keeping
+	// each group intact produces the highest total partition score.
+	node.AddLink(0, 1, links.TwoNVLINKLinks)
+	node.AddLink(1, 0, links.TwoNVLINKLinks)
+	for i := range node {
+		for j := range node {
+			if i == j {
+				continue
+			}
+			linkType := links.P2PLinkCrossCPU
+			if (i < 2 && j < 2) || (i >= 2 && j >= 2) {
+				linkType = links.P2PLinkSingleSwitch
+			}
+			node.AddLink(i, j, linkType)
+		}
+	}
+	devices := node.Devices()
+	t.Run("policy", func(t *testing.T) {
+		allocated := NewBestEffortPolicy().Allocate(devices, nil, 3)
+		for _, device := range allocated {
+			require.NotNil(t, device, "allocation must not contain padding")
+		}
+		require.ElementsMatch(t, devices[2:], allocated)
+	})
+	t.Run("required device", func(t *testing.T) {
+		allocated := NewBestEffortPolicy().Allocate(devices, devices[2:3], 3)
+		require.ElementsMatch(t, devices[2:], allocated)
+	})
+	t.Run("allocator", func(t *testing.T) {
+		allocator := newAllocatorFrom(devices, NewBestEffortPolicy())
+		allocated := allocator.Allocate(3)
+		require.ElementsMatch(t, devices[2:], allocated)
+		require.ElementsMatch(t, devices[:2], allocator.Allocate(2))
+		require.Empty(t, allocator.Allocate(1))
+		allocator.Free(allocated...)
+		require.ElementsMatch(t, allocated, allocator.Allocate(3))
+	})
 }


### PR DESCRIPTION
The best-effort policy pads available devices with nil entries when their count is not divisible by the requested allocation size. Partition selection requires a complete candidate set, but final set selection can still choose a higher-scoring padded set.

With five available GPUs, an NVLink pair can outscore a complete three-GPU group. Requesting three GPUs then returns two devices and nil, causing `Allocator.Allocate` to panic.

Exclude padded sets from final selection while preserving the existing partition scoring. The regression test covers required devices and subsequent allocation/free operations using the existing topology test model. It fails with the allocation panic on the upstream baseline and passes with this change.

Validation:
- `make test`
- `go test -race ./... -count=1`
- `make golangci-lint` (0 issues)

No physical GPU validation was needed for the policy regression test.
